### PR TITLE
Configure Cloudflare Pages deployment

### DIFF
--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -18,6 +18,9 @@ const storySitemapUrls = storyRoutes.map((loc) => ({
 export default defineNuxtConfig({
   compatibilityDate: "2024-11-01",
   devtools: { enabled: true },
+  nitro: {
+    preset: "cloudflare_pages",
+  },
   css: [
     join(currentDir, "app/assets/css/main.css"),
     join(currentDir, "app/assets/css/transitions.css"),

--- a/package.json
+++ b/package.json
@@ -4,9 +4,10 @@
   "type": "module",
   "scripts": {
     "build": "nuxi build",
+    "deploy": "nuxi build && wrangler pages deploy dist --project-name=hegdeheartbeats --branch=main",
     "dev": "nuxi dev",
     "generate": "nuxi generate",
-    "preview": "nuxi preview",
+    "preview": "npx wrangler --cwd dist pages dev",
     "postinstall": "nuxi prepare"
   },
   "dependencies": {


### PR DESCRIPTION
## Summary
- Set Nitro preset to `cloudflare_pages` for NuxtHub builds targeting Cloudflare Pages
- Add `deploy` script to build and publish to the `hegdeheartbeats` Pages project via wrangler
- Update `preview` script to use `wrangler pages dev` for local Cloudflare Pages preview

## Test plan
- [x] `NITRO_PRESET=cloudflare_pages bun run build` completes successfully
- [x] `wrangler pages deploy dist --project-name=hegdeheartbeats` deploys to production
- [x] https://ink.aksharahegde.xyz loads without console errors
- [ ] `bun run deploy` works end-to-end after merge


Made with [Cursor](https://cursor.com)