### PR TITLE
Add llms.txt and markdown export routes

### DIFF
--- a/app/app.vue
+++ b/app/app.vue
@@ -32,6 +32,15 @@ const config = useRuntimeConfig();
 const siteUrl = config.public.baseURL ?? "";
 const twitterHandle = config.public.twitter?.trim();
 
+const markdownAlternateHref = computed(() => {
+  if (!siteUrl) return undefined;
+  const base = siteUrl.replace(/\/$/, "");
+  if (route.path === "/") return `${base}/index.md`;
+  const storyMatch = route.path.match(/^\/stories\/([^/]+)$/);
+  if (storyMatch) return `${base}/stories/${storyMatch[1]}.md`;
+  return `${base}${route.path.replace(/\/$/, "")}.md`;
+});
+
 useHead({
   titleTemplate: (title) => {
     if (!title) return config.public.siteName ?? "Ink";
@@ -48,11 +57,14 @@ useHead({
     { name: "theme-color", content: "#f4f1ea" },
     { name: "msapplication-TileColor", content: "#f4f1ea" },
   ],
-  link: [
+  link: computed(() => [
     { rel: "icon", type: "image/png", href: "/icon.png" },
     { rel: "mask-icon", color: "#fff", href: "/favicon.ico" },
     { rel: "icon", type: "image/ico", href: "/favicon.ico" },
-  ],
+    ...(markdownAlternateHref.value
+      ? [{ rel: "alternate", type: "text/markdown", href: markdownAlternateHref.value }]
+      : []),
+  ]),
 });
 
 useSeoMeta({

--- a/app/pages/about.vue
+++ b/app/pages/about.vue
@@ -12,24 +12,18 @@
       class="font-serif text-lg leading-relaxed space-y-6"
       style="color: var(--ink-text);"
     >
-      <p>
-        My name is not enough to know about me. But still I have to tell about I, me and myself.
-      </p>
-      <p>
-        My name is Hegde. Software Development is my profession. I love to do it. Apart from my professional work, I compose music for my own songs. Sometimes I write poems and stories.
-      </p>
-      <p>
-        More than all these facts, Am a chaser of success, not the people. So many people came and gone out of my life. But the one thing that always remaining with me is confidence, determination to achieve something.. not to impress others.. it's to express my power and knowledge.
+      <p v-for="(paragraph, index) in aboutParagraphs" :key="index">
+        {{ paragraph }}
       </p>
       <p>
         <a
-          href="https://x.com/akshara_dev"
+          :href="aboutTwitterUrl"
           target="_blank"
           rel="noopener noreferrer"
           class="hover:opacity-80 transition-opacity"
           style="color: var(--ink-accent); text-decoration: underline; text-underline-offset: 0.2em;"
         >
-          Twitter: https://x.com/akshara_dev
+          Twitter: {{ aboutTwitterUrl }}
         </a>
       </p>
     </div>
@@ -38,28 +32,30 @@
 </template>
 
 <script setup lang="ts">
-const config = useRuntimeConfig();
+import { aboutParagraphs, aboutTwitterUrl } from '#shared/about-content'
+
+const config = useRuntimeConfig()
 
 definePageMeta({
-  title: "About",
-});
+  title: 'About',
+})
 
-const description = `About ${config.public.ownerName} — software developer, musician, and storyteller behind Ink.`;
+const description = `About ${config.public.ownerName} — software developer, musician, and storyteller behind Ink.`
 
 useSeoMeta({
-  title: "About",
+  title: 'About',
   description,
   ogTitle: `About - ${config.public.siteName}`,
   ogDescription: description,
   twitterTitle: `About - ${config.public.siteName}`,
   twitterDescription: description,
-});
+})
 
 useSchemaOrg([
   defineWebPage({
-    "@type": "AboutPage",
-    name: "About",
+    '@type': 'AboutPage',
+    name: 'About',
     description,
   }),
-]);
+])
 </script>

--- a/modules/llm-content/index.ts
+++ b/modules/llm-content/index.ts
@@ -1,0 +1,199 @@
+import { readdirSync, readFileSync } from 'node:fs'
+import { join } from 'node:path'
+import { addServerHandler, addTypeTemplate, createResolver, defineNuxtModule, useNuxt } from 'nuxt/kit'
+import { pageMeta } from '../../shared/page-meta'
+
+type FrontmatterRecord = Record<string, string | boolean | number | undefined>
+
+export type LlmStory = {
+  slug: string
+  title: string
+  author?: string
+  description?: string
+  category?: string
+  readingTime?: string
+  date?: string
+  body: string
+}
+
+export type LlmSummary = {
+  slug: string
+  title: string
+  author?: string
+  description?: string
+  category?: string
+  readingTime?: string
+  date?: string
+  path?: string
+  body: string
+}
+
+export type LlmHome = {
+  title?: string
+  description?: string
+  quote?: string
+}
+
+function parseFrontmatter (content: string): { data: FrontmatterRecord, body: string } {
+  if (!content.startsWith('---')) {
+    return { data: {}, body: content.trim() }
+  }
+
+  const end = content.indexOf('\n---', 3)
+  if (end === -1) {
+    return { data: {}, body: content.trim() }
+  }
+
+  const raw = content.slice(4, end)
+  const body = content.slice(end + 4).replace(/^\n/, '')
+  const data: FrontmatterRecord = {}
+
+  for (const line of raw.split('\n')) {
+    const match = line.match(/^([\w-]+):\s*(.*)$/)
+    if (!match) continue
+    const [, key, value] = match
+    const trimmed = value.replace(/^["']|["']$/g, '')
+    if (trimmed === 'true') data[key] = true
+    else if (trimmed === 'false') data[key] = false
+    else if (/^\d+$/.test(trimmed)) data[key] = Number(trimmed)
+    else data[key] = trimmed
+  }
+
+  return { data, body: body.trim() }
+}
+
+function readMarkdownDir (dir: string, filter: (name: string) => boolean) {
+  return readdirSync(dir)
+    .filter(name => name.endsWith('.md') && filter(name))
+    .map(name => {
+      const filePath = join(dir, name)
+      const content = readFileSync(filePath, 'utf8')
+      const { data, body } = parseFrontmatter(content)
+      const slug = String(data.slug ?? name.replace(/\.md$/, ''))
+      return { slug, data, body, filePath }
+    })
+}
+
+export default defineNuxtModule({
+  meta: {
+    name: 'llm-content',
+  },
+  setup () {
+    const nuxt = useNuxt()
+    const resolver = createResolver(import.meta.url)
+    const rootDir = nuxt.options.rootDir
+
+    const storiesDir = join(rootDir, 'content/stories')
+    const summariesDir = join(rootDir, 'content/stories/summary')
+    const homePath = join(rootDir, 'content/index.md')
+
+    const storyFiles = readMarkdownDir(storiesDir, name => name !== 'index.md')
+    const summaryFiles = readMarkdownDir(summariesDir, () => true)
+
+    const stories: LlmStory[] = storyFiles.map(({ slug, data, body }) => ({
+      slug,
+      title: String(data.title ?? slug),
+      author: data.author ? String(data.author) : undefined,
+      description: data.description ? String(data.description) : undefined,
+      category: data.category ? String(data.category) : undefined,
+      readingTime: data.readingTime ? String(data.readingTime) : undefined,
+      date: data.date ? String(data.date) : undefined,
+      body,
+    }))
+
+    const summaries: LlmSummary[] = summaryFiles.map(({ slug, data, body }) => ({
+      slug,
+      title: String(data.title ?? slug),
+      author: data.author ? String(data.author) : undefined,
+      description: data.description ? String(data.description) : undefined,
+      category: data.category ? String(data.category) : undefined,
+      readingTime: data.readingTime ? String(data.readingTime) : undefined,
+      date: data.date ? String(data.date) : undefined,
+      path: data.path ? String(data.path) : `/stories/${slug}`,
+      body,
+    }))
+
+    let home: LlmHome = {}
+    try {
+      const homeContent = readFileSync(homePath, 'utf8')
+      const { data } = parseFrontmatter(homeContent)
+      home = {
+        title: data.title ? String(data.title) : undefined,
+        description: data.description ? String(data.description) : undefined,
+        quote: data.quote ? String(data.quote) : undefined,
+      }
+    } catch {
+      // content/index.md optional
+    }
+
+    nuxt.options.nitro.virtual ||= {}
+    nuxt.options.nitro.virtual['#llm-page-meta.json'] = () =>
+      `export const pageMeta = ${JSON.stringify(pageMeta)}`
+    nuxt.options.nitro.virtual['#llm-stories.json'] = () =>
+      `export const llmStories = ${JSON.stringify(stories)}`
+    nuxt.options.nitro.virtual['#llm-summaries.json'] = () =>
+      `export const llmSummaries = ${JSON.stringify(summaries)}`
+    nuxt.options.nitro.virtual['#llm-home.json'] = () =>
+      `export const llmHome = ${JSON.stringify(home)}`
+
+    nuxt.options.nitro.externals ||= {}
+    nuxt.options.nitro.externals.inline ||= []
+    nuxt.options.nitro.externals.inline.push(
+      '#llm-page-meta.json',
+      '#llm-stories.json',
+      '#llm-summaries.json',
+      '#llm-home.json',
+    )
+
+    for (const story of stories) {
+      addServerHandler({
+        route: `/stories/${story.slug}.md`,
+        handler: resolver.resolve('./runtime/story-md.get'),
+      })
+    }
+
+    addTypeTemplate({
+      filename: 'types/llm-content.d.ts',
+      getContents: () => `
+declare module '#llm-page-meta.json' {
+  export const pageMeta: Record<string, { title: string, description?: string, llmLabel?: string }>
+}
+
+declare module '#llm-stories.json' {
+  export const llmStories: Array<{
+    slug: string
+    title: string
+    author?: string
+    description?: string
+    category?: string
+    readingTime?: string
+    date?: string
+    body: string
+  }>
+}
+
+declare module '#llm-summaries.json' {
+  export const llmSummaries: Array<{
+    slug: string
+    title: string
+    author?: string
+    description?: string
+    category?: string
+    readingTime?: string
+    date?: string
+    path?: string
+    body: string
+  }>
+}
+
+declare module '#llm-home.json' {
+  export const llmHome: {
+    title?: string
+    description?: string
+    quote?: string
+  }
+}
+`,
+    })
+  },
+})

--- a/modules/llm-content/runtime/story-md.get.ts
+++ b/modules/llm-content/runtime/story-md.get.ts
@@ -1,0 +1,45 @@
+import { llmStories } from '#llm-stories.json'
+
+export default defineEventHandler((event) => {
+  if (import.meta.test) {
+    return mdResponse('')
+  }
+
+  const pathname = getRequestURL(event).pathname
+  const match = pathname.match(/^\/stories\/(.+)\.md$/)
+  const slug = match?.[1]
+
+  if (!slug) {
+    throw createError({ statusCode: 404, statusMessage: 'Not found' })
+  }
+
+  const story = llmStories.find(s => s.slug === slug)
+
+  if (!story) {
+    throw createError({ statusCode: 404, statusMessage: 'Not found' })
+  }
+
+  const base = siteBase(event)
+  const esc = (s: string) => s.replace(/\\/g, '\\\\').replace(/"/g, '\\"')
+
+  const frontmatterLines = [
+    '---',
+    `title: "${esc(story.title)}"`,
+    `url: ${base}/stories/${story.slug}`,
+  ]
+  if (story.author) frontmatterLines.push(`author: "${esc(story.author)}"`)
+  if (story.description) frontmatterLines.push(`description: "${esc(story.description)}"`)
+  if (story.category) frontmatterLines.push(`category: "${esc(story.category)}"`)
+  if (story.readingTime) frontmatterLines.push(`readingTime: "${esc(story.readingTime)}"`)
+  if (story.date) frontmatterLines.push(`date: ${story.date}`)
+  frontmatterLines.push('---')
+
+  const md = [
+    ...frontmatterLines,
+    '',
+    story.body,
+    '',
+  ].join('\n')
+
+  return mdResponse(md)
+})

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -9,6 +9,15 @@ const storyRoutes = readdirSync(join(currentDir, "content/stories/summary"))
   .filter((file) => file.endsWith(".md"))
   .map((file) => `/stories/${file.replace(/\.md$/, "")}`);
 
+const llmRoutes = [
+  "/llms.txt",
+  "/llms-full.txt",
+  "/index.md",
+  "/about.md",
+  "/stories.md",
+  ...storyRoutes.map((route) => `${route}.md`),
+];
+
 const storySitemapUrls = storyRoutes.map((loc) => ({
   loc,
   changefreq: "monthly" as const,
@@ -38,6 +47,7 @@ export default defineNuxtConfig({
     "@nuxt/fonts",
     "@nuxthub/core",
     "@nuxt/image",
+    "./modules/llm-content",
   ],
   fonts: {
     families: [
@@ -60,6 +70,12 @@ export default defineNuxtConfig({
     "/stories": { prerender: true },
     "/stories/[slug]": { prerender: true },
     "/ws/**": { prerender: false },
+    "/llms.txt": { prerender: true },
+    "/llms-full.txt": { prerender: true },
+    "/index.md": { prerender: true },
+    "/about.md": { prerender: true },
+    "/stories.md": { prerender: true },
+    "/stories/**/*.md": { prerender: true },
   },
   app: {
     head: {
@@ -127,7 +143,7 @@ export default defineNuxtConfig({
     "nitro:config"(nitroConfig) {
       nitroConfig.prerender = nitroConfig.prerender || {};
       const existing = nitroConfig.prerender.routes || [];
-      nitroConfig.prerender.routes = [...new Set([...existing, ...storyRoutes])];
+      nitroConfig.prerender.routes = [...new Set([...existing, ...storyRoutes, ...llmRoutes])];
     },
   },
   robots: {

--- a/server/routes/about.md.get.ts
+++ b/server/routes/about.md.get.ts
@@ -1,0 +1,21 @@
+import { pageMeta } from '#llm-page-meta.json'
+import { aboutParagraphs, aboutTwitterUrl } from '#shared/about-content'
+
+export default defineEventHandler((event) => {
+  if (import.meta.test) {
+    return mdResponse('')
+  }
+
+  const base = siteBase(event)
+
+  const md = [
+    mdFrontmatter(base, '/about', pageMeta['/about']!),
+    '',
+    ...aboutParagraphs,
+    '',
+    `[Twitter](${aboutTwitterUrl})`,
+    '',
+  ].join('\n')
+
+  return mdResponse(md)
+})

--- a/server/routes/index.md.get.ts
+++ b/server/routes/index.md.get.ts
@@ -1,0 +1,42 @@
+import { pageMeta } from '#llm-page-meta.json'
+import { llmSummaries } from '#llm-summaries.json'
+import { llmHome } from '#llm-home.json'
+
+export default defineEventHandler((event) => {
+  if (import.meta.test) {
+    return mdResponse('')
+  }
+
+  const base = siteBase(event)
+  const config = useRuntimeConfig(event)
+  const ownerName = config.public.ownerName ?? 'Akshara Hegde'
+
+  const recentStories = llmSummaries.slice(0, 5)
+  const quote = llmHome.quote ?? 'Some stories stay with you long after the last word.'
+
+  const lines = [
+    mdFrontmatter(base, '/', pageMeta['/']!),
+    '',
+    llmHome.description
+      ?? `Love. Loss. Memory. Mystery. A collection of emotional narrative stories by ${ownerName}.`,
+    '',
+    `> ${quote}`,
+    '',
+    `[More about ${ownerName}](${base}/about.md)`,
+    '',
+  ]
+
+  if (recentStories.length) {
+    lines.push('## Recent Stories')
+    lines.push('')
+    for (const story of recentStories) {
+      const category = story.category ? ` — ${story.category}` : ''
+      lines.push(`- [${story.title}](${base}/stories/${story.slug}.md)${category}`)
+    }
+    lines.push('')
+    lines.push(`[All stories](${base}/stories.md)`)
+    lines.push('')
+  }
+
+  return mdResponse(lines.join('\n'))
+})

--- a/server/routes/llms-full.txt.get.ts
+++ b/server/routes/llms-full.txt.get.ts
@@ -1,0 +1,59 @@
+import { llmStories } from '#llm-stories.json'
+import { llmHome } from '#llm-home.json'
+import { aboutParagraphs, aboutTwitterUrl } from '#shared/about-content'
+
+export default defineEventHandler((event) => {
+  if (import.meta.test) {
+    return txtResponse('')
+  }
+
+  const base = siteBase(event)
+  const config = useRuntimeConfig(event)
+  const ownerName = config.public.ownerName ?? 'Akshara Hegde'
+  const siteName = config.public.siteName ?? 'Ink'
+
+  const tagline = llmHome.description
+    ?? `A collection of short stories from the heart by ${ownerName}.`
+
+  const lines = [
+    `# ${siteName} — Stories by ${ownerName}`,
+    '',
+    `> ${tagline}`,
+    '',
+    '---',
+    '',
+    '## About the Author',
+    '',
+    ...aboutParagraphs,
+    '',
+    '---',
+    '',
+  ]
+
+  for (const story of llmStories) {
+    lines.push(`## ${story.title}`)
+    lines.push('')
+    if (story.author) lines.push(`- **Author:** ${story.author}`)
+    if (story.category) lines.push(`- **Category:** ${story.category}`)
+    if (story.readingTime) lines.push(`- **Reading time:** ${story.readingTime}`)
+    if (story.date) lines.push(`- **Date:** ${story.date}`)
+    lines.push(`- **URL:** ${base}/stories/${story.slug}.md`)
+    if (story.description) {
+      lines.push('')
+      lines.push(story.description)
+    }
+    lines.push('')
+    lines.push(story.body)
+    lines.push('')
+    lines.push('---')
+    lines.push('')
+  }
+
+  lines.push('## Contact')
+  lines.push('')
+  lines.push(`- Twitter: ${aboutTwitterUrl}`)
+  lines.push(`- Website: ${base}`)
+  lines.push('')
+
+  return txtResponse(lines.join('\n'))
+})

--- a/server/routes/llms.txt.get.ts
+++ b/server/routes/llms.txt.get.ts
@@ -1,0 +1,60 @@
+import { pageMeta } from '#llm-page-meta.json'
+import { llmSummaries } from '#llm-summaries.json'
+import { llmHome } from '#llm-home.json'
+import { aboutTwitterUrl } from '#shared/about-content'
+
+export default defineEventHandler((event) => {
+  if (import.meta.test) {
+    return txtResponse('')
+  }
+
+  const base = siteBase(event)
+  const config = useRuntimeConfig(event)
+  const ownerName = config.public.ownerName ?? 'Akshara Hegde'
+  const siteName = config.public.siteName ?? 'Ink'
+
+  const pageIndex = Object.entries(pageMeta)
+    .filter(([, meta]) => meta.llmLabel)
+    .map(([path, meta]) => {
+      const mdPath = path === '/' ? '/index.md' : `${path}.md`
+      return `- [${meta.title}](${base}${mdPath}): ${meta.llmLabel}`
+    })
+
+  const recentStories = llmSummaries.slice(0, 5)
+
+  const tagline = llmHome.description
+    ?? `A collection of short stories from the heart by ${ownerName}.`
+
+  const lines = [
+    `# ${siteName} — Stories by ${ownerName}`,
+    '',
+    `> ${tagline}`,
+    '',
+    '## About',
+    '',
+    ...pageIndex,
+    '',
+    '## Key Links',
+    '',
+    `- Website: ${base}`,
+    `- Twitter: ${aboutTwitterUrl}`,
+    '',
+  ]
+
+  if (recentStories.length) {
+    lines.push('## Recent Stories')
+    lines.push('')
+    for (const story of recentStories) {
+      const category = story.category ? ` — ${story.category}` : ''
+      lines.push(`- [${story.title}](${base}/stories/${story.slug}.md)${category}`)
+    }
+    lines.push('')
+  }
+
+  lines.push('## Optional')
+  lines.push('')
+  lines.push(`- [Full content](${base}/llms-full.txt): Complete about section and all stories in a single document`)
+  lines.push('')
+
+  return txtResponse(lines.join('\n'))
+})

--- a/server/routes/stories.md.get.ts
+++ b/server/routes/stories.md.get.ts
@@ -1,0 +1,32 @@
+import { pageMeta } from '#llm-page-meta.json'
+import { llmSummaries } from '#llm-summaries.json'
+
+export default defineEventHandler((event) => {
+  if (import.meta.test) {
+    return mdResponse('')
+  }
+
+  const base = siteBase(event)
+
+  const lines = [
+    mdFrontmatter(base, '/stories', pageMeta['/stories']!),
+    '',
+  ]
+
+  for (const story of llmSummaries) {
+    lines.push(`## ${story.title}`)
+    lines.push('')
+    if (story.author) lines.push(`- **Author:** ${story.author}`)
+    if (story.category) lines.push(`- **Category:** ${story.category}`)
+    if (story.readingTime) lines.push(`- **Reading time:** ${story.readingTime}`)
+    if (story.description) {
+      lines.push('')
+      lines.push(story.description)
+    }
+    lines.push('')
+    lines.push(`[Read full story](${base}/stories/${story.slug}.md)`)
+    lines.push('')
+  }
+
+  return mdResponse(lines.join('\n'))
+})

--- a/server/utils/md.ts
+++ b/server/utils/md.ts
@@ -1,0 +1,44 @@
+function yamlEscape (str: string): string {
+  return str.replace(/\\/g, '\\\\').replace(/"/g, '\\"')
+}
+
+export function mdFrontmatter (
+  siteUrl: string,
+  path: string,
+  meta: { title: string, description?: string },
+): string {
+  const lines = ['---']
+  lines.push(`title: "${yamlEscape(meta.title)}"`)
+  if (meta.description) {
+    lines.push(`description: "${yamlEscape(meta.description)}"`)
+  }
+  lines.push(`url: ${siteUrl}${path}`)
+  lines.push('---')
+  return lines.join('\n')
+}
+
+export function mdResponse (content: string): Response {
+  return new Response(content, {
+    headers: { 'Content-Type': 'text/markdown; charset=utf-8' },
+  })
+}
+
+export function txtResponse (content: string): Response {
+  return new Response(content, {
+    headers: { 'Content-Type': 'text/plain; charset=utf-8' },
+  })
+}
+
+export function formatDate (dateStr: string): string {
+  const date = new Date(dateStr)
+  return date.toLocaleDateString('en-GB', {
+    day: 'numeric',
+    month: 'long',
+    year: 'numeric',
+  })
+}
+
+export function siteBase (event?: Parameters<typeof getRequestURL>[0]): string {
+  const config = useRuntimeConfig(event)
+  return String(config.public.baseURL ?? '').replace(/\/$/, '')
+}

--- a/shared/about-content.ts
+++ b/shared/about-content.ts
@@ -1,0 +1,7 @@
+export const aboutParagraphs = [
+  'My name is not enough to know about me. But still I have to tell about I, me and myself.',
+  'My name is Hegde. Software Development is my profession. I love to do it. Apart from my professional work, I compose music for my own songs. Sometimes I write poems and stories.',
+  'More than all these facts, Am a chaser of success, not the people. So many people came and gone out of my life. But the one thing that always remaining with me is confidence, determination to achieve something.. not to impress others.. it\'s to express my power and knowledge.',
+] as const
+
+export const aboutTwitterUrl = 'https://x.com/akshara_dev'

--- a/shared/page-meta.ts
+++ b/shared/page-meta.ts
@@ -1,0 +1,24 @@
+export type PageMeta = {
+  title: string
+  description?: string
+  /** Short label used in llms.txt page index. Pages without this are excluded. */
+  llmLabel?: string
+}
+
+export const pageMeta: Record<string, PageMeta> = {
+  '/': {
+    title: 'Ink',
+    description: 'Love. Loss. Memory. Mystery. A collection of emotional narrative stories by Akshara Hegde.',
+    llmLabel: 'Home — story collection',
+  },
+  '/about': {
+    title: 'About',
+    description: 'About Akshara Hegde — software developer, musician, and storyteller behind Ink.',
+    llmLabel: 'About the author',
+  },
+  '/stories': {
+    title: 'Stories',
+    description: 'A collection of narrative stories by Akshara Hegde.',
+    llmLabel: 'All stories index',
+  },
+}


### PR DESCRIPTION
## Summary
- Adds `/llms.txt` (compact index) and `/llms-full.txt` (full story dump) for LLM-readable discovery
- Exports per-page markdown at `/index.md`, `/about.md`, `/stories.md`, and `/stories/{slug}.md`
- Introduces `llm-content` module with build-time content scanning and explicit story `.md` route registration
- Adds `text/markdown` alternate links in app head

## Test plan
- [x] `npm run build` completes without prerender errors
- [x] `dist/llms.txt` and `dist/llms-full.txt` generated
- [x] Story HTML pages and `.md` exports prerender correctly


Made with [Cursor](https://cursor.com)