### PR TITLE
Add book mode reader for stories

### DIFF
--- a/app/app.vue
+++ b/app/app.vue
@@ -1,18 +1,23 @@
 <template>
   <UApp>
-    <main class="min-h-screen" style="background-color: var(--ink-bg); color: var(--ink-text);">
-      <Navbar />
+    <main
+      class="min-h-screen"
+      :class="{ 'book-focus-shell': isBookFocusMode }"
+      style="background-color: var(--ink-bg); color: var(--ink-text);"
+    >
+      <Navbar v-if="!isBookFocusMode" />
       <div>
         <NuxtPage />
       </div>
-      <Footer />
+      <Footer v-if="!isBookFocusMode" />
       <ClientOnly>
-        <LazyPresenceVisitorPresence v-if="canShowPresence" />
+        <LazyPresenceVisitorPresence v-if="canShowPresence && !isBookFocusMode" />
       </ClientOnly>
     </main>
   </UApp>
 </template>
 <script setup lang="ts">
+const { mode } = useReadingMode();
 const canShowPresence = ref(false);
 
 onMounted(() => {
@@ -31,6 +36,7 @@ const route = useRoute();
 const config = useRuntimeConfig();
 const siteUrl = config.public.baseURL ?? "";
 const twitterHandle = config.public.twitter?.trim();
+const isBookFocusMode = computed(() => mode.value === "book" && /^\/stories\/[^/]+$/.test(route.path));
 
 const markdownAlternateHref = computed(() => {
   if (!siteUrl) return undefined;

--- a/app/assets/css/reading.css
+++ b/app/assets/css/reading.css
@@ -194,3 +194,239 @@ html.dark .reading-prose hr {
     transition: none;
   }
 }
+
+/* Book mode reader */
+.book-mode-reader {
+  width: min(92vw, 1080px);
+  margin-left: 50%;
+  transform: translateX(-50%);
+  outline: none;
+}
+
+.book-mode-source {
+  position: fixed;
+  top: 0;
+  left: -200vw;
+  width: min(42vw, 470px);
+  height: auto;
+  visibility: hidden;
+  pointer-events: none;
+}
+
+.book-page-measure {
+  position: fixed;
+  top: 0;
+  left: -200vw;
+  width: min(42vw, 470px);
+  height: clamp(520px, 68vh, 760px);
+  visibility: hidden;
+  pointer-events: none;
+  z-index: -1;
+}
+
+.book-stage {
+  position: relative;
+  padding: clamp(1rem, 3vw, 2.5rem);
+  perspective: 1800px;
+}
+
+.book-cover {
+  position: absolute;
+  inset: clamp(0.35rem, 1vw, 0.8rem);
+  border-radius: 18px 24px 24px 18px;
+  background:
+    linear-gradient(90deg, rgba(56, 28, 12, 0.42), transparent 8%, transparent 92%, rgba(36, 18, 8, 0.38)),
+    linear-gradient(135deg, #5f2415, #2f1711 55%, #1f120f);
+  box-shadow: 0 34px 80px rgba(35, 24, 15, 0.32);
+  transform: rotateX(2deg);
+}
+
+html.dark .book-cover {
+  box-shadow: 0 34px 80px rgba(0, 0, 0, 0.5);
+}
+
+.book-spread {
+  position: relative;
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) 18px minmax(0, 1fr);
+  min-height: clamp(520px, 68vh, 760px);
+  transform-style: preserve-3d;
+}
+
+.book-page {
+  position: relative;
+  overflow: hidden;
+  min-height: clamp(520px, 68vh, 760px);
+  padding: clamp(1.5rem, 3vw, 3rem);
+  background:
+    radial-gradient(circle at 20% 10%, rgba(255, 255, 255, 0.65), transparent 36%),
+    linear-gradient(90deg, rgba(124, 45, 18, 0.08), transparent 9%),
+    var(--ink-paper);
+  border: 1px solid color-mix(in srgb, var(--ink-border) 80%, transparent);
+  box-shadow: inset 0 0 38px rgba(124, 45, 18, 0.08);
+}
+
+.book-page-left {
+  border-radius: 10px 3px 3px 10px;
+  transform-origin: right center;
+}
+
+.book-page-right {
+  border-radius: 3px 10px 10px 3px;
+  transform-origin: left center;
+  background:
+    radial-gradient(circle at 80% 10%, rgba(255, 255, 255, 0.62), transparent 36%),
+    linear-gradient(270deg, rgba(124, 45, 18, 0.08), transparent 9%),
+    var(--ink-paper);
+}
+
+.book-spine {
+  position: relative;
+  background:
+    linear-gradient(90deg, rgba(0, 0, 0, 0.18), rgba(255, 255, 255, 0.24), rgba(0, 0, 0, 0.16)),
+    color-mix(in srgb, var(--ink-border) 72%, var(--ink-text));
+  box-shadow:
+    inset 7px 0 18px rgba(0, 0, 0, 0.16),
+    inset -7px 0 18px rgba(0, 0, 0, 0.12);
+}
+
+.book-page-content {
+  font-size: 0.98rem;
+  line-height: 1.78;
+}
+
+.book-mode-reader[data-reading-size="0"] .book-page-content,
+.book-mode-reader[data-reading-size="0"] .book-mode-source,
+.book-mode-reader[data-reading-size="0"] .book-page-measure {
+  font-size: 0.9rem;
+}
+
+.book-mode-reader[data-reading-size="2"] .book-page-content,
+.book-mode-reader[data-reading-size="2"] .book-mode-source,
+.book-mode-reader[data-reading-size="2"] .book-page-measure {
+  font-size: 1.08rem;
+}
+
+.book-page-content > :first-child {
+  margin-top: 0;
+}
+
+.book-page-empty {
+  display: grid;
+  min-height: 100%;
+  place-items: center;
+  color: var(--ink-muted);
+  font-family: "Inter", ui-sans-serif, system-ui, sans-serif;
+  font-size: 0.875rem;
+}
+
+.is-flipping-next .book-page-right {
+  animation: book-flip-next 520ms cubic-bezier(0.2, 0.7, 0.2, 1);
+}
+
+.is-flipping-prev .book-page-left {
+  animation: book-flip-prev 520ms cubic-bezier(0.2, 0.7, 0.2, 1);
+}
+
+@keyframes book-flip-next {
+  0% { transform: rotateY(0deg); filter: brightness(1); }
+  48% { transform: rotateY(-84deg); filter: brightness(0.88); }
+  100% { transform: rotateY(0deg); filter: brightness(1); }
+}
+
+@keyframes book-flip-prev {
+  0% { transform: rotateY(0deg); filter: brightness(1); }
+  48% { transform: rotateY(84deg); filter: brightness(0.88); }
+  100% { transform: rotateY(0deg); filter: brightness(1); }
+}
+
+.book-controls {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 1rem;
+  margin-top: 1rem;
+  color: var(--ink-muted);
+}
+
+.book-control {
+  min-height: 2.75rem;
+  padding: 0 1rem;
+  border: 1px solid var(--ink-border);
+  border-radius: 9999px;
+  background: var(--ink-paper);
+  color: var(--ink-text);
+  transition:
+    border-color 0.2s ease,
+    color 0.2s ease,
+    opacity 0.2s ease,
+    transform 0.2s ease;
+}
+
+.book-control:hover:not(:disabled) {
+  border-color: var(--ink-accent);
+  color: var(--ink-accent);
+  transform: translateY(-1px);
+}
+
+.book-control:disabled {
+  cursor: not-allowed;
+  opacity: 0.35;
+}
+
+.book-page-count {
+  min-width: 8.5rem;
+  text-align: center;
+  font-size: 0.875rem;
+}
+
+@media (max-width: 767px) {
+  .book-mode-reader,
+  .book-mode-source,
+  .book-page-measure {
+    width: min(92vw, 430px);
+  }
+
+  .book-stage {
+    padding: 0.75rem;
+  }
+
+  .book-spread {
+    grid-template-columns: minmax(0, 1fr);
+    min-height: clamp(500px, 68vh, 680px);
+  }
+
+  .book-page,
+  .book-page-measure {
+    min-height: clamp(500px, 68vh, 680px);
+    height: clamp(500px, 68vh, 680px);
+    padding: 1.35rem;
+  }
+
+  .book-spine {
+    display: none;
+  }
+
+  .book-page-left {
+    border-radius: 10px;
+  }
+
+  .book-controls {
+    gap: 0.6rem;
+  }
+
+  .book-page-count {
+    min-width: 6rem;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .is-flipping-next .book-page-right,
+  .is-flipping-prev .book-page-left {
+    animation: none;
+  }
+
+  .book-control {
+    transition: none;
+  }
+}

--- a/app/assets/css/reading.css
+++ b/app/assets/css/reading.css
@@ -251,6 +251,7 @@ html.dark .book-cover {
   grid-template-columns: minmax(0, 1fr) 18px minmax(0, 1fr);
   min-height: clamp(520px, 68vh, 760px);
   transform-style: preserve-3d;
+  isolation: isolate;
 }
 
 .book-page {
@@ -290,18 +291,21 @@ html.dark .book-cover {
     inset -7px 0 18px rgba(0, 0, 0, 0.12);
 }
 
-.book-page-content {
+.book-page-content,
+.book-turn-face {
   font-size: 0.98rem;
   line-height: 1.78;
 }
 
 .book-mode-reader[data-reading-size="0"] .book-page-content,
+.book-mode-reader[data-reading-size="0"] .book-turn-face,
 .book-mode-reader[data-reading-size="0"] .book-mode-source,
 .book-mode-reader[data-reading-size="0"] .book-page-measure {
   font-size: 0.9rem;
 }
 
 .book-mode-reader[data-reading-size="2"] .book-page-content,
+.book-mode-reader[data-reading-size="2"] .book-turn-face,
 .book-mode-reader[data-reading-size="2"] .book-mode-source,
 .book-mode-reader[data-reading-size="2"] .book-page-measure {
   font-size: 1.08rem;
@@ -320,24 +324,82 @@ html.dark .book-cover {
   font-size: 0.875rem;
 }
 
-.is-flipping-next .book-page-right {
-  animation: book-flip-next 520ms cubic-bezier(0.2, 0.7, 0.2, 1);
+.book-turn-sheet {
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  width: calc((100% - 18px) / 2);
+  transform-style: preserve-3d;
+  z-index: 5;
+  pointer-events: none;
 }
 
-.is-flipping-prev .book-page-left {
-  animation: book-flip-prev 520ms cubic-bezier(0.2, 0.7, 0.2, 1);
+.book-turn-face {
+  position: absolute;
+  inset: 0;
+  overflow: hidden;
+  padding: clamp(1.5rem, 3vw, 3rem);
+  background:
+    radial-gradient(circle at 20% 10%, rgba(255, 255, 255, 0.65), transparent 36%),
+    linear-gradient(90deg, rgba(124, 45, 18, 0.08), transparent 9%),
+    var(--ink-paper);
+  border: 1px solid color-mix(in srgb, var(--ink-border) 80%, transparent);
+  box-shadow:
+    inset 0 0 38px rgba(124, 45, 18, 0.08),
+    0 20px 46px rgba(35, 24, 15, 0.18);
+  backface-visibility: hidden;
 }
 
-@keyframes book-flip-next {
-  0% { transform: rotateY(0deg); filter: brightness(1); }
-  48% { transform: rotateY(-84deg); filter: brightness(0.88); }
-  100% { transform: rotateY(0deg); filter: brightness(1); }
+.book-turn-front {
+  transform: rotateY(0deg);
 }
 
-@keyframes book-flip-prev {
-  0% { transform: rotateY(0deg); filter: brightness(1); }
-  48% { transform: rotateY(84deg); filter: brightness(0.88); }
-  100% { transform: rotateY(0deg); filter: brightness(1); }
+.book-turn-back {
+  transform: rotateY(180deg);
+}
+
+.is-flipping-next .book-turn-sheet {
+  left: calc((100% + 18px) / 2);
+  transform-origin: left center;
+  animation: book-full-flip-next 700ms cubic-bezier(0.18, 0.72, 0.18, 1) both;
+}
+
+.is-flipping-prev .book-turn-sheet {
+  left: 0;
+  transform-origin: right center;
+  animation: book-full-flip-prev 700ms cubic-bezier(0.18, 0.72, 0.18, 1) both;
+}
+
+@keyframes book-full-flip-next {
+  0% {
+    transform: rotateY(0deg);
+    filter: brightness(1);
+  }
+
+  45% {
+    filter: brightness(0.82);
+  }
+
+  100% {
+    transform: rotateY(-180deg);
+    filter: brightness(1);
+  }
+}
+
+@keyframes book-full-flip-prev {
+  0% {
+    transform: rotateY(0deg);
+    filter: brightness(1);
+  }
+
+  45% {
+    filter: brightness(0.82);
+  }
+
+  100% {
+    transform: rotateY(180deg);
+    filter: brightness(1);
+  }
 }
 
 .book-controls {
@@ -397,7 +459,8 @@ html.dark .book-cover {
   }
 
   .book-page,
-  .book-page-measure {
+  .book-page-measure,
+  .book-turn-face {
     min-height: clamp(500px, 68vh, 680px);
     height: clamp(500px, 68vh, 680px);
     padding: 1.35rem;
@@ -411,6 +474,15 @@ html.dark .book-cover {
     border-radius: 10px;
   }
 
+  .book-turn-sheet {
+    width: 100%;
+  }
+
+  .is-flipping-next .book-turn-sheet,
+  .is-flipping-prev .book-turn-sheet {
+    left: 0;
+  }
+
   .book-controls {
     gap: 0.6rem;
   }
@@ -421,8 +493,8 @@ html.dark .book-cover {
 }
 
 @media (prefers-reduced-motion: reduce) {
-  .is-flipping-next .book-page-right,
-  .is-flipping-prev .book-page-left {
+  .is-flipping-next .book-turn-sheet,
+  .is-flipping-prev .book-turn-sheet {
     animation: none;
   }
 

--- a/app/assets/css/reading.css
+++ b/app/assets/css/reading.css
@@ -32,24 +32,6 @@ html.dark .reading-prose {
   font-size: 1.3125rem;
 }
 
-/* Drop cap for first paragraph */
-.reading-prose > p:first-of-type::first-letter,
-.reading-prose > :first-child p:first-of-type::first-letter {
-  font-family: "Playfair Display", ui-serif, Georgia, serif;
-  float: left;
-  font-size: 4.5em;
-  line-height: 0.8;
-  padding-right: 0.1em;
-  margin-top: 0.05em;
-  font-weight: 700;
-  color: var(--reading-heading);
-}
-
-html.dark .reading-prose > p:first-of-type::first-letter,
-html.dark .reading-prose > :first-child p:first-of-type::first-letter {
-  color: var(--reading-heading-dark);
-}
-
 .reading-prose p {
   margin-bottom: 1.75rem;
   color: var(--reading-text);
@@ -196,11 +178,76 @@ html.dark .reading-prose hr {
 }
 
 /* Book mode reader */
+.book-focus-shell {
+  height: 100svh;
+  overflow: hidden;
+}
+
+.book-focus-page {
+  height: 100svh;
+  min-height: 100svh;
+  overflow: hidden;
+  padding: 0;
+}
+
+.book-focus-content {
+  box-sizing: border-box;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 100%;
+  height: 100svh;
+  padding: clamp(0.75rem, 2vw, 1.5rem);
+}
+
+.book-focus-content > .story-reader {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 100%;
+  height: 100%;
+}
+
 .book-mode-reader {
-  width: min(92vw, 1080px);
-  margin-left: 50%;
-  transform: translateX(-50%);
+  --book-page-height: min(760px, calc(100svh - 8.5rem));
+
+  display: grid;
+  grid-template-rows: minmax(0, 1fr) auto;
+  align-items: center;
+  gap: clamp(0.75rem, 2vh, 1.25rem);
+  width: min(96vw, 1180px);
+  height: 100%;
+  margin: 0 auto;
   outline: none;
+}
+
+.book-focus-exit {
+  position: fixed;
+  top: 1rem;
+  right: 1rem;
+  z-index: 50;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 2.75rem;
+  height: 2.75rem;
+  padding: 0;
+  border: 1px solid var(--ink-border);
+  border-radius: 9999px;
+  background: color-mix(in srgb, var(--ink-paper) 92%, transparent);
+  color: var(--ink-text);
+  box-shadow: 0 14px 32px rgba(35, 24, 15, 0.14);
+  backdrop-filter: blur(10px);
+  transition:
+    border-color 0.2s ease,
+    color 0.2s ease,
+    transform 0.2s ease;
+}
+
+.book-focus-exit:hover {
+  border-color: var(--ink-accent);
+  color: var(--ink-accent);
+  transform: translateY(-1px);
 }
 
 .book-mode-source {
@@ -218,7 +265,7 @@ html.dark .reading-prose hr {
   top: 0;
   left: -200vw;
   width: min(42vw, 470px);
-  height: clamp(520px, 68vh, 760px);
+  height: var(--book-page-height);
   visibility: hidden;
   pointer-events: none;
   z-index: -1;
@@ -226,7 +273,12 @@ html.dark .reading-prose hr {
 
 .book-stage {
   position: relative;
-  padding: clamp(1rem, 3vw, 2.5rem);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 100%;
+  min-height: 0;
+  padding: clamp(0.75rem, 2vw, 1.5rem);
   perspective: 1800px;
 }
 
@@ -249,7 +301,9 @@ html.dark .book-cover {
   position: relative;
   display: grid;
   grid-template-columns: minmax(0, 1fr) 18px minmax(0, 1fr);
-  min-height: clamp(520px, 68vh, 760px);
+  width: 100%;
+  height: var(--book-page-height);
+  min-height: 0;
   transform-style: preserve-3d;
   isolation: isolate;
 }
@@ -257,7 +311,8 @@ html.dark .book-cover {
 .book-page {
   position: relative;
   overflow: hidden;
-  min-height: clamp(520px, 68vh, 760px);
+  height: 100%;
+  min-height: 0;
   padding: clamp(1.5rem, 3vw, 3rem);
   background:
     radial-gradient(circle at 20% 10%, rgba(255, 255, 255, 0.65), transparent 36%),
@@ -265,6 +320,10 @@ html.dark .book-cover {
     var(--ink-paper);
   border: 1px solid color-mix(in srgb, var(--ink-border) 80%, transparent);
   box-shadow: inset 0 0 38px rgba(124, 45, 18, 0.08);
+}
+
+.book-mode-reader .book-page-measure {
+  height: var(--book-page-height);
 }
 
 .book-page-left {
@@ -407,7 +466,7 @@ html.dark .book-cover {
   align-items: center;
   justify-content: center;
   gap: 1rem;
-  margin-top: 1rem;
+  margin-top: 0;
   color: var(--ink-muted);
 }
 
@@ -443,27 +502,43 @@ html.dark .book-cover {
 }
 
 @media (max-width: 767px) {
+  .book-focus-content {
+    padding: 0.75rem;
+  }
+
   .book-mode-reader,
   .book-mode-source,
   .book-page-measure {
+    --book-page-height: min(680px, calc(100svh - 8rem));
+
     width: min(92vw, 430px);
   }
 
   .book-stage {
-    padding: 0.75rem;
+    padding: 3.75rem 0 0;
+  }
+
+  .book-focus-exit {
+    top: 0.75rem;
+    right: 0.75rem;
   }
 
   .book-spread {
     grid-template-columns: minmax(0, 1fr);
-    min-height: clamp(500px, 68vh, 680px);
+    height: var(--book-page-height);
+    min-height: 0;
   }
 
   .book-page,
   .book-page-measure,
   .book-turn-face {
-    min-height: clamp(500px, 68vh, 680px);
-    height: clamp(500px, 68vh, 680px);
+    height: var(--book-page-height);
+    min-height: 0;
     padding: 1.35rem;
+  }
+
+  .book-mode-reader .book-page-measure {
+    height: var(--book-page-height);
   }
 
   .book-spine {
@@ -499,6 +574,10 @@ html.dark .book-cover {
   }
 
   .book-control {
+    transition: none;
+  }
+
+  .book-focus-exit {
     transition: none;
   }
 }

--- a/app/components/ReadingToolbar.vue
+++ b/app/components/ReadingToolbar.vue
@@ -44,6 +44,18 @@
     <button
       type="button"
       class="min-h-12 min-w-12 inline-flex items-center justify-center rounded-full transition-opacity hover:opacity-70"
+      :style="{ color: isBookMode ? 'var(--ink-accent)' : 'var(--ink-muted)' }"
+      data-testid="story-bookmode-toggle"
+      :aria-label="isBookMode ? 'Switch to scroll mode' : 'Switch to book mode'"
+      :aria-pressed="isBookMode"
+      @click="toggleMode"
+    >
+      <svg xmlns="http://www.w3.org/2000/svg" width="17" height="17" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M12 7v14" /><path d="M3 18a1 1 0 0 1-1-1V4a1 1 0 0 1 1-1h5a4 4 0 0 1 4 4 4 4 0 0 1 4-4h5a1 1 0 0 1 1 1v13a1 1 0 0 1-1 1h-6a3 3 0 0 0-3 3 3 3 0 0 0-3-3z" /></svg>
+    </button>
+    <div class="w-px h-5 mx-0.5" :style="{ backgroundColor: 'var(--ink-border)' }" aria-hidden="true" />
+    <button
+      type="button"
+      class="min-h-12 min-w-12 inline-flex items-center justify-center rounded-full transition-opacity hover:opacity-70"
       :style="{ color: 'var(--ink-muted)' }"
       aria-label="Share story"
       @click="onShare"
@@ -62,11 +74,13 @@ const props = defineProps<{
 }>();
 
 const { level: fontLevel, increase, decrease, MIN: minLevel, MAX: maxLevel } = useReadingFontSize();
+const { mode, toggleMode } = useReadingMode();
 const colorMode = useColorMode();
 const isDark = computed({
   get: () => colorMode.value === "dark",
   set: (v: boolean) => { colorMode.preference = v ? "dark" : "light"; },
 });
+const isBookMode = computed(() => mode.value === "book");
 
 async function onShare() {
   try {

--- a/app/components/reading/BookModeReader.vue
+++ b/app/components/reading/BookModeReader.vue
@@ -20,6 +20,32 @@
       aria-hidden="true"
     />
 
+    <button
+      type="button"
+      class="book-focus-exit"
+      data-testid="story-bookmode-toggle"
+      aria-label="Switch to normal mode"
+      @click="setMode('scroll')"
+    >
+      <svg
+        xmlns="http://www.w3.org/2000/svg"
+        width="18"
+        height="18"
+        viewBox="0 0 24 24"
+        fill="none"
+        stroke="currentColor"
+        stroke-width="2"
+        stroke-linecap="round"
+        stroke-linejoin="round"
+        aria-hidden="true"
+      >
+        <path d="M15 3h6v6" />
+        <path d="M10 14 21 3" />
+        <path d="M9 21H3v-6" />
+        <path d="M14 10 3 21" />
+      </svg>
+    </button>
+
     <div
       class="book-stage"
       :class="{
@@ -118,6 +144,7 @@ const prefersReducedMotion = ref(false);
 const turnFrontPage = ref("");
 const turnBackPage = ref("");
 const pendingPage = ref<number | null>(null);
+const { setMode } = useReadingMode();
 const { playFlip } = usePageFlipAudio();
 const { pages, pageCount, isPaginating, schedulePagination } = useBookPagination({
   sourceEl,

--- a/app/components/reading/BookModeReader.vue
+++ b/app/components/reading/BookModeReader.vue
@@ -54,6 +54,22 @@
           />
           <div v-else class="book-page-empty" />
         </article>
+
+        <div
+          v-if="flipDirection && turnFrontPage"
+          class="book-turn-sheet"
+          aria-hidden="true"
+          @animationend="finishFlip"
+        >
+          <div
+            class="book-turn-face book-turn-front reading-prose prose prose-lg max-w-none"
+            v-html="turnFrontPage"
+          />
+          <div
+            class="book-turn-face book-turn-back reading-prose prose prose-lg max-w-none"
+            v-html="turnBackPage"
+          />
+        </div>
       </div>
     </div>
 
@@ -99,6 +115,9 @@ const currentPage = ref(0);
 const isSinglePage = ref(false);
 const flipDirection = ref<"next" | "prev" | null>(null);
 const prefersReducedMotion = ref(false);
+const turnFrontPage = ref("");
+const turnBackPage = ref("");
+const pendingPage = ref<number | null>(null);
 const { playFlip } = usePageFlipAudio();
 const { pages, pageCount, isPaginating, schedulePagination } = useBookPagination({
   sourceEl,
@@ -113,10 +132,15 @@ let flipTimer: ReturnType<typeof setTimeout> | undefined;
 
 const step = computed(() => isSinglePage.value ? 1 : 2);
 const spreadStart = computed(() => isSinglePage.value ? currentPage.value : Math.floor(currentPage.value / 2) * 2);
-const leftPage = computed(() => pages.value[spreadStart.value]);
-const rightPage = computed(() => pages.value[spreadStart.value + 1]);
-const canGoPrev = computed(() => spreadStart.value > 0);
-const canGoNext = computed(() => spreadStart.value + step.value < pageCount.value);
+const displayedPage = computed(() => pendingPage.value ?? currentPage.value);
+const displayedSpreadStart = computed(() =>
+  isSinglePage.value ? displayedPage.value : Math.floor(displayedPage.value / 2) * 2
+);
+const leftPage = computed(() => pages.value[displayedSpreadStart.value]);
+const rightPage = computed(() => pages.value[displayedSpreadStart.value + 1]);
+const isFlipping = computed(() => flipDirection.value !== null);
+const canGoPrev = computed(() => !isFlipping.value && spreadStart.value > 0);
+const canGoNext = computed(() => !isFlipping.value && spreadStart.value + step.value < pageCount.value);
 
 const pageLabel = computed(() => {
   if (isPaginating.value || pageCount.value === 0) return "Preparing pages";
@@ -138,13 +162,39 @@ function clampCurrentPage() {
   if (!isSinglePage.value) currentPage.value = Math.floor(currentPage.value / 2) * 2;
 }
 
-function setFlip(direction: "next" | "prev") {
-  if (prefersReducedMotion.value) return;
-  flipDirection.value = direction;
+function finishFlip() {
   clearTimeout(flipTimer);
-  flipTimer = setTimeout(() => {
-    flipDirection.value = null;
-  }, 520);
+
+  if (pendingPage.value !== null) {
+    currentPage.value = pendingPage.value;
+    pendingPage.value = null;
+    clampCurrentPage();
+  }
+
+  flipDirection.value = null;
+  turnFrontPage.value = "";
+  turnBackPage.value = "";
+}
+
+function setFlip(direction: "next" | "prev", nextPage: number) {
+  if (prefersReducedMotion.value) {
+    currentPage.value = nextPage;
+    clampCurrentPage();
+    return;
+  }
+
+  const nextSpreadStart = isSinglePage.value ? nextPage : Math.floor(nextPage / 2) * 2;
+  flipDirection.value = direction;
+  pendingPage.value = nextPage;
+  turnFrontPage.value = direction === "next"
+    ? pages.value[spreadStart.value + (isSinglePage.value ? 0 : 1)] ?? ""
+    : pages.value[spreadStart.value] ?? "";
+  turnBackPage.value = direction === "next"
+    ? pages.value[nextSpreadStart] ?? ""
+    : pages.value[nextSpreadStart + (isSinglePage.value ? 0 : 1)] ?? pages.value[nextSpreadStart] ?? "";
+
+  clearTimeout(flipTimer);
+  flipTimer = setTimeout(finishFlip, 900);
 }
 
 async function turnPage(direction: "next" | "prev") {
@@ -154,9 +204,7 @@ async function turnPage(direction: "next" | "prev") {
 
   if (nextPage === currentPage.value) return;
 
-  currentPage.value = nextPage;
-  clampCurrentPage();
-  setFlip(direction);
+  setFlip(direction, nextPage);
   await playFlip();
 }
 

--- a/app/components/reading/BookModeReader.vue
+++ b/app/components/reading/BookModeReader.vue
@@ -1,0 +1,220 @@
+<template>
+  <section
+    ref="readerRoot"
+    class="book-mode-reader"
+    :data-reading-size="fontLevel"
+    tabindex="0"
+    aria-label="Book mode reader"
+  >
+    <div
+      ref="sourceEl"
+      class="book-mode-source reading-prose prose prose-lg max-w-none"
+      aria-hidden="true"
+    >
+      <ContentRenderer :value="story" />
+    </div>
+
+    <div
+      ref="measureEl"
+      class="book-page book-page-measure"
+      aria-hidden="true"
+    />
+
+    <div
+      class="book-stage"
+      :class="{
+        'is-single-page': isSinglePage,
+        'is-flipping-next': flipDirection === 'next',
+        'is-flipping-prev': flipDirection === 'prev',
+      }"
+    >
+      <div class="book-cover" aria-hidden="true" />
+      <div class="book-spread">
+        <article class="book-page book-page-left">
+          <div
+            v-if="leftPage"
+            class="book-page-content reading-prose prose prose-lg max-w-none"
+            v-html="leftPage"
+          />
+          <div v-else class="book-page-empty">
+            Preparing pages...
+          </div>
+        </article>
+
+        <div class="book-spine" aria-hidden="true" />
+
+        <article
+          v-if="!isSinglePage"
+          class="book-page book-page-right"
+        >
+          <div
+            v-if="rightPage"
+            class="book-page-content reading-prose prose prose-lg max-w-none"
+            v-html="rightPage"
+          />
+          <div v-else class="book-page-empty" />
+        </article>
+      </div>
+    </div>
+
+    <div class="book-controls font-meta" aria-label="Book page controls">
+      <button
+        type="button"
+        class="book-control"
+        data-testid="story-book-prev"
+        :disabled="!canGoPrev"
+        aria-label="Previous page"
+        @click="goPrev"
+      >
+        Previous
+      </button>
+      <span class="book-page-count" aria-live="polite">
+        {{ pageLabel }}
+      </span>
+      <button
+        type="button"
+        class="book-control"
+        data-testid="story-book-next"
+        :disabled="!canGoNext"
+        aria-label="Next page"
+        @click="goNext"
+      >
+        Next
+      </button>
+    </div>
+  </section>
+</template>
+
+<script setup lang="ts">
+const props = defineProps<{
+  story: Record<string, unknown>;
+  fontLevel: number;
+}>();
+
+const readerRoot = ref<HTMLElement | null>(null);
+const sourceEl = ref<HTMLElement | null>(null);
+const measureEl = ref<HTMLElement | null>(null);
+const fontLevelRef = toRef(props, "fontLevel");
+const currentPage = ref(0);
+const isSinglePage = ref(false);
+const flipDirection = ref<"next" | "prev" | null>(null);
+const prefersReducedMotion = ref(false);
+const { playFlip } = usePageFlipAudio();
+const { pages, pageCount, isPaginating, schedulePagination } = useBookPagination({
+  sourceEl,
+  measureEl,
+  fontLevel: fontLevelRef,
+});
+
+let mutationObserver: MutationObserver | undefined;
+let mediaQuery: MediaQueryList | undefined;
+let reducedMotionQuery: MediaQueryList | undefined;
+let flipTimer: ReturnType<typeof setTimeout> | undefined;
+
+const step = computed(() => isSinglePage.value ? 1 : 2);
+const spreadStart = computed(() => isSinglePage.value ? currentPage.value : Math.floor(currentPage.value / 2) * 2);
+const leftPage = computed(() => pages.value[spreadStart.value]);
+const rightPage = computed(() => pages.value[spreadStart.value + 1]);
+const canGoPrev = computed(() => spreadStart.value > 0);
+const canGoNext = computed(() => spreadStart.value + step.value < pageCount.value);
+
+const pageLabel = computed(() => {
+  if (isPaginating.value || pageCount.value === 0) return "Preparing pages";
+  const first = spreadStart.value + 1;
+  const last = isSinglePage.value || !rightPage.value ? first : first + 1;
+  return first === last
+    ? `Page ${first} of ${pageCount.value}`
+    : `Pages ${first}-${last} of ${pageCount.value}`;
+});
+
+function clampCurrentPage() {
+  if (pageCount.value === 0) {
+    currentPage.value = 0;
+    return;
+  }
+
+  const maxPage = Math.max(0, pageCount.value - 1);
+  currentPage.value = Math.min(currentPage.value, maxPage);
+  if (!isSinglePage.value) currentPage.value = Math.floor(currentPage.value / 2) * 2;
+}
+
+function setFlip(direction: "next" | "prev") {
+  if (prefersReducedMotion.value) return;
+  flipDirection.value = direction;
+  clearTimeout(flipTimer);
+  flipTimer = setTimeout(() => {
+    flipDirection.value = null;
+  }, 520);
+}
+
+async function turnPage(direction: "next" | "prev") {
+  const nextPage = direction === "next"
+    ? Math.min(currentPage.value + step.value, Math.max(0, pageCount.value - 1))
+    : Math.max(currentPage.value - step.value, 0);
+
+  if (nextPage === currentPage.value) return;
+
+  currentPage.value = nextPage;
+  clampCurrentPage();
+  setFlip(direction);
+  await playFlip();
+}
+
+function goNext() {
+  void turnPage("next");
+}
+
+function goPrev() {
+  void turnPage("prev");
+}
+
+function onKeydown(event: KeyboardEvent) {
+  if (event.key === "ArrowRight") {
+    event.preventDefault();
+    goNext();
+  }
+
+  if (event.key === "ArrowLeft") {
+    event.preventDefault();
+    goPrev();
+  }
+}
+
+function updateMediaState() {
+  isSinglePage.value = mediaQuery?.matches ?? false;
+  prefersReducedMotion.value = reducedMotionQuery?.matches ?? false;
+  clampCurrentPage();
+  schedulePagination();
+}
+
+function observeRenderedContent() {
+  if (!sourceEl.value) return;
+
+  mutationObserver = new MutationObserver(schedulePagination);
+  mutationObserver.observe(sourceEl.value, { childList: true, subtree: true });
+
+  sourceEl.value.querySelectorAll("img").forEach((image) => {
+    image.addEventListener("load", schedulePagination, { once: true });
+  });
+}
+
+onMounted(() => {
+  mediaQuery = window.matchMedia("(max-width: 767px)");
+  reducedMotionQuery = window.matchMedia("(prefers-reduced-motion: reduce)");
+  mediaQuery.addEventListener("change", updateMediaState);
+  reducedMotionQuery.addEventListener("change", updateMediaState);
+  readerRoot.value?.addEventListener("keydown", onKeydown);
+  observeRenderedContent();
+  updateMediaState();
+});
+
+onBeforeUnmount(() => {
+  mutationObserver?.disconnect();
+  mediaQuery?.removeEventListener("change", updateMediaState);
+  reducedMotionQuery?.removeEventListener("change", updateMediaState);
+  readerRoot.value?.removeEventListener("keydown", onKeydown);
+  clearTimeout(flipTimer);
+});
+
+watch([pageCount, isSinglePage], clampCurrentPage);
+</script>

--- a/app/components/reading/ScrollStoryReader.vue
+++ b/app/components/reading/ScrollStoryReader.vue
@@ -1,0 +1,27 @@
+<template>
+  <div
+    class="reading-prose-wrapper"
+    :data-reading-size="fontLevel"
+  >
+    <ClientOnly>
+      <article
+        v-reading-fade-in
+        class="reading-prose prose prose-lg max-w-none"
+      >
+        <ContentRenderer :value="story" />
+      </article>
+      <template #fallback>
+        <article class="reading-prose prose prose-lg max-w-none">
+          <ContentRenderer :value="story" />
+        </article>
+      </template>
+    </ClientOnly>
+  </div>
+</template>
+
+<script setup lang="ts">
+defineProps<{
+  story: Record<string, unknown>;
+  fontLevel: number;
+}>();
+</script>

--- a/app/components/reading/StoryReader.vue
+++ b/app/components/reading/StoryReader.vue
@@ -1,0 +1,36 @@
+<template>
+  <div class="story-reader">
+    <ClientOnly v-if="mode === 'book'">
+      <BookModeReader
+        v-if="story"
+        :story="story"
+        :font-level="fontLevel"
+      />
+      <template #fallback>
+        <ScrollStoryReader
+          v-if="story"
+          :story="story"
+          :font-level="fontLevel"
+        />
+      </template>
+    </ClientOnly>
+
+    <ScrollStoryReader
+      v-else-if="story"
+      :story="story"
+      :font-level="fontLevel"
+    />
+  </div>
+</template>
+
+<script setup lang="ts">
+import BookModeReader from "~/components/reading/BookModeReader.vue";
+import ScrollStoryReader from "~/components/reading/ScrollStoryReader.vue";
+
+defineProps<{
+  story: Record<string, unknown> | null;
+  fontLevel: number;
+}>();
+
+const { mode } = useReadingMode();
+</script>

--- a/app/composables/useBookPagination.ts
+++ b/app/composables/useBookPagination.ts
@@ -1,0 +1,137 @@
+import type { Ref } from "vue";
+
+type BookPaginationOptions = {
+  sourceEl: Ref<HTMLElement | null>;
+  measureEl: Ref<HTMLElement | null>;
+  fontLevel: Ref<number>;
+};
+
+export function useBookPagination({ sourceEl, measureEl, fontLevel }: BookPaginationOptions) {
+  const pages = ref<string[]>([]);
+  const isPaginating = ref(true);
+  let resizeObserver: ResizeObserver | undefined;
+  let paginationFrame = 0;
+
+  const pageCount = computed(() => pages.value.length);
+
+  function collectBlocks() {
+    const source = sourceEl.value;
+    if (!source) return [];
+    const contentRoot = source.children.length === 1 && source.firstElementChild instanceof HTMLElement
+      ? source.firstElementChild
+      : source;
+    return Array.from(contentRoot.children).filter((child) => child instanceof HTMLElement) as HTMLElement[];
+  }
+
+  function createTextClone(block: HTMLElement, text: string) {
+    const clone = block.cloneNode(false) as HTMLElement;
+    clone.textContent = text;
+    return clone;
+  }
+
+  function splitTextBlock(block: HTMLElement, measure: HTMLElement) {
+    if (block.tagName !== "P") return [];
+
+    const words = (block.textContent ?? "").split(/\s+/).filter(Boolean);
+    if (words.length < 2) return [];
+
+    const splitPages: string[] = [];
+    let chunk: string[] = [];
+
+    for (const word of words) {
+      chunk.push(word);
+      measure.innerHTML = "";
+      measure.appendChild(createTextClone(block, chunk.join(" ")));
+
+      if (measure.scrollHeight <= measure.clientHeight + 2) continue;
+
+      chunk.pop();
+      if (chunk.length > 0) {
+        measure.innerHTML = "";
+        measure.appendChild(createTextClone(block, chunk.join(" ")));
+        splitPages.push(measure.innerHTML);
+      }
+      chunk = [word];
+    }
+
+    if (chunk.length > 0) {
+      measure.innerHTML = "";
+      measure.appendChild(createTextClone(block, chunk.join(" ")));
+      splitPages.push(measure.innerHTML);
+    }
+
+    measure.innerHTML = "";
+    return splitPages;
+  }
+
+  function paginateNow() {
+    const measure = measureEl.value;
+    const blocks = collectBlocks();
+
+    if (!measure || blocks.length === 0) {
+      pages.value = [];
+      isPaginating.value = blocks.length === 0;
+      return;
+    }
+
+    isPaginating.value = true;
+    measure.innerHTML = "";
+
+    const nextPages: string[] = [];
+
+    for (const block of blocks) {
+      const before = measure.innerHTML;
+      measure.appendChild(block.cloneNode(true));
+
+      if (measure.scrollHeight <= measure.clientHeight + 2) continue;
+
+      if (before) {
+        nextPages.push(before);
+        measure.innerHTML = "";
+        measure.appendChild(block.cloneNode(true));
+      }
+
+      if (measure.scrollHeight > measure.clientHeight + 2 && measure.children.length === 1) {
+        const splitPages = splitTextBlock(block, measure);
+        nextPages.push(...(splitPages.length > 0 ? splitPages : [measure.innerHTML]));
+        measure.innerHTML = "";
+      }
+    }
+
+    if (measure.innerHTML) nextPages.push(measure.innerHTML);
+
+    pages.value = nextPages;
+    isPaginating.value = false;
+  }
+
+  function schedulePagination() {
+    if (!import.meta.client) return;
+    cancelAnimationFrame(paginationFrame);
+    paginationFrame = requestAnimationFrame(() => {
+      requestAnimationFrame(paginateNow);
+    });
+  }
+
+  onMounted(() => {
+    schedulePagination();
+
+    if (measureEl.value) {
+      resizeObserver = new ResizeObserver(schedulePagination);
+      resizeObserver.observe(measureEl.value);
+    }
+  });
+
+  onBeforeUnmount(() => {
+    cancelAnimationFrame(paginationFrame);
+    resizeObserver?.disconnect();
+  });
+
+  watch(fontLevel, schedulePagination);
+
+  return {
+    pages,
+    pageCount,
+    isPaginating,
+    schedulePagination,
+  };
+}

--- a/app/composables/useBookPagination.ts
+++ b/app/composables/useBookPagination.ts
@@ -29,6 +29,39 @@ export function useBookPagination({ sourceEl, measureEl, fontLevel }: BookPagina
     return clone;
   }
 
+  function isHeading(block: HTMLElement) {
+    return /^H[1-6]$/.test(block.tagName);
+  }
+
+  function isChapterEnd(block: HTMLElement) {
+    return block.tagName === "HR";
+  }
+
+  function getKeepWithNextGroup(blocks: HTMLElement[], startIndex: number) {
+    const group: HTMLElement[] = [];
+    let index = startIndex;
+
+    while (blocks[index] && isHeading(blocks[index])) {
+      group.push(blocks[index]);
+      index += 1;
+    }
+
+    if (group.length > 0 && blocks[index]) group.push(blocks[index]);
+    return group;
+  }
+
+  function groupFitsCurrentPage(measure: HTMLElement, group: HTMLElement[]) {
+    const before = measure.innerHTML;
+    for (const block of group) measure.appendChild(block.cloneNode(true));
+    const fits = measure.scrollHeight <= measure.clientHeight + 2;
+    measure.innerHTML = before;
+    return fits;
+  }
+
+  function nextBlockIsChapterEnd(blocks: HTMLElement[], index: number) {
+    return Boolean(blocks[index + 1] && isChapterEnd(blocks[index + 1]));
+  }
+
   function splitTextBlock(block: HTMLElement, measure: HTMLElement) {
     if (block.tagName !== "P") return [];
 
@@ -79,11 +112,35 @@ export function useBookPagination({ sourceEl, measureEl, fontLevel }: BookPagina
 
     const nextPages: string[] = [];
 
-    for (const block of blocks) {
+    for (let i = 0; i < blocks.length; i += 1) {
+      const block = blocks[i];
+
+      if (measure.innerHTML && nextBlockIsChapterEnd(blocks, i)) {
+        const group = [block, blocks[i + 1]];
+        if (!groupFitsCurrentPage(measure, group)) {
+          nextPages.push(measure.innerHTML);
+          measure.innerHTML = "";
+        }
+      }
+
+      if (isHeading(block)) {
+        const group = getKeepWithNextGroup(blocks, i);
+        if (measure.innerHTML && group.length > 1 && !groupFitsCurrentPage(measure, group)) {
+          nextPages.push(measure.innerHTML);
+          measure.innerHTML = "";
+        }
+      }
+
       const before = measure.innerHTML;
       measure.appendChild(block.cloneNode(true));
 
       if (measure.scrollHeight <= measure.clientHeight + 2) continue;
+
+      if (isChapterEnd(block) && before) {
+        nextPages.push(measure.innerHTML);
+        measure.innerHTML = "";
+        continue;
+      }
 
       if (before) {
         nextPages.push(before);

--- a/app/composables/usePageFlipAudio.ts
+++ b/app/composables/usePageFlipAudio.ts
@@ -1,0 +1,44 @@
+export function usePageFlipAudio() {
+  let audioContext: AudioContext | null = null;
+
+  function getContext() {
+    if (!import.meta.client) return null;
+    audioContext ??= new AudioContext();
+    return audioContext;
+  }
+
+  async function playFlip() {
+    const context = getContext();
+    if (!context) return;
+
+    if (context.state === "suspended") await context.resume();
+
+    const duration = 0.16;
+    const buffer = context.createBuffer(1, context.sampleRate * duration, context.sampleRate);
+    const data = buffer.getChannelData(0);
+
+    for (let i = 0; i < data.length; i += 1) {
+      const progress = i / data.length;
+      data[i] = (Math.random() * 2 - 1) * (1 - progress) * 0.28;
+    }
+
+    const source = context.createBufferSource();
+    const filter = context.createBiquadFilter();
+    const gain = context.createGain();
+
+    source.buffer = buffer;
+    filter.type = "highpass";
+    filter.frequency.setValueAtTime(550, context.currentTime);
+    gain.gain.setValueAtTime(0.0001, context.currentTime);
+    gain.gain.exponentialRampToValueAtTime(0.2, context.currentTime + 0.02);
+    gain.gain.exponentialRampToValueAtTime(0.0001, context.currentTime + duration);
+
+    source.connect(filter);
+    filter.connect(gain);
+    gain.connect(context.destination);
+    source.start();
+    source.stop(context.currentTime + duration);
+  }
+
+  return { playFlip };
+}

--- a/app/composables/useReadingMode.ts
+++ b/app/composables/useReadingMode.ts
@@ -1,0 +1,47 @@
+const STORAGE_KEY = "ink-reading-mode";
+
+export type ReadingMode = "scroll" | "book";
+
+const DEFAULT: ReadingMode = "scroll";
+
+function isReadingMode(value: string | null): value is ReadingMode {
+  return value === "scroll" || value === "book";
+}
+
+export function useReadingMode() {
+  const mode = useState<ReadingMode>("reading-mode", () => DEFAULT);
+
+  function persist(value: ReadingMode) {
+    if (import.meta.client) {
+      try {
+        localStorage.setItem(STORAGE_KEY, value);
+      } catch {
+        /**/
+      }
+    }
+  }
+
+  function hydrate() {
+    if (import.meta.client) {
+      try {
+        const raw = localStorage.getItem(STORAGE_KEY);
+        if (isReadingMode(raw)) mode.value = raw;
+      } catch {
+        /**/
+      }
+    }
+  }
+
+  function setMode(value: ReadingMode) {
+    mode.value = value;
+    persist(value);
+  }
+
+  function toggleMode() {
+    setMode(mode.value === "book" ? "scroll" : "book");
+  }
+
+  onMounted(hydrate);
+
+  return { mode, setMode, toggleMode };
+}

--- a/app/pages/stories/[slug].vue
+++ b/app/pages/stories/[slug].vue
@@ -54,24 +54,11 @@
 
     <!-- Story content -->
     <div class="max-w-[680px] mx-auto px-4 pt-10 md:pt-14">
-      <div
-        class="reading-prose-wrapper"
-        :data-reading-size="fontLevel"
-      >
-        <ClientOnly>
-          <article
-            v-reading-fade-in
-            class="reading-prose prose prose-lg max-w-none"
-          >
-            <ContentRenderer v-if="story" :value="story" />
-          </article>
-          <template #fallback>
-            <article class="reading-prose prose prose-lg max-w-none">
-              <ContentRenderer v-if="story" :value="story" />
-            </article>
-          </template>
-        </ClientOnly>
-      </div>
+      <StoryReader
+        v-if="story"
+        :story="story"
+        :font-level="fontLevel"
+      />
     </div>
 
     <!-- Reading toolbar -->
@@ -97,6 +84,7 @@
 </template>
 
 <script setup lang="ts">
+import StoryReader from "~/components/reading/StoryReader.vue";
 import { useReadingFontSize } from "~/composables/useReadingFontSize";
 
 const route = useRoute();

--- a/app/pages/stories/[slug].vue
+++ b/app/pages/stories/[slug].vue
@@ -1,9 +1,12 @@
 <template>
-  <div class="view-transition pb-20">
-    <ReadingProgressBar />
+  <div
+    class="view-transition"
+    :class="isBookMode ? 'book-focus-page' : 'pb-20'"
+  >
+    <ReadingProgressBar v-if="!isBookMode" />
 
     <!-- Story header -->
-    <header class="max-w-[680px] mx-auto px-4 pt-12 md:pt-20">
+    <header v-if="!isBookMode" class="max-w-[680px] mx-auto px-4 pt-12 md:pt-20">
       <!-- Top rule -->
       <hr class="ink-rule mb-8" />
 
@@ -39,7 +42,7 @@
     </header>
 
     <!-- Cover image -->
-    <div v-if="coverImage" class="max-w-3xl mx-auto px-4 mt-10">
+    <div v-if="coverImage && !isBookMode" class="max-w-3xl mx-auto px-4 mt-10">
       <div class="relative aspect-[16/9] overflow-hidden">
         <img
           :src="coverImage"
@@ -53,7 +56,9 @@
     </div>
 
     <!-- Story content -->
-    <div class="max-w-[680px] mx-auto px-4 pt-10 md:pt-14">
+    <div
+      :class="isBookMode ? 'book-focus-content' : 'max-w-[680px] mx-auto px-4 pt-10 md:pt-14'"
+    >
       <StoryReader
         v-if="story"
         :story="story"
@@ -63,13 +68,13 @@
 
     <!-- Reading toolbar -->
     <ReadingToolbar
-      v-if="story"
+      v-if="story && !isBookMode"
       :share-title="story.title ?? ''"
       :share-url="shareUrl"
     />
 
     <!-- Recommendations -->
-    <div v-if="story" class="max-w-[680px] mx-auto px-4">
+    <div v-if="story && !isBookMode" class="max-w-[680px] mx-auto px-4">
       <StoryRecommendations
         :current-slug="(story.meta?.slug ?? story.slug ?? route.params.slug) as string"
         :stories="allSummaries"
@@ -77,7 +82,7 @@
     </div>
 
     <!-- Not found -->
-    <div v-else class="max-w-[680px] mx-auto px-4 py-16 text-center" style="color: var(--ink-muted);">
+    <div v-if="!story" class="max-w-[680px] mx-auto px-4 py-16 text-center" style="color: var(--ink-muted);">
       Story not found
     </div>
   </div>
@@ -91,6 +96,8 @@ const route = useRoute();
 const config = useRuntimeConfig();
 
 const { level: fontLevel } = useReadingFontSize();
+const { mode } = useReadingMode();
+const isBookMode = computed(() => mode.value === "book");
 
 const shareUrl = computed(() => {
   const base = config.public.baseURL ?? "";


### PR DESCRIPTION
## Summary
- Add an opt-in physical book reader for story pages with full-page flip animation and flip audio.
- Make Book mode a focused fullscreen reading surface with only pagination and an icon to return to normal mode.
- Improve pagination so full story content renders, headings stay with chapter starts, and horizontal rules stay with chapter endings.

## Test plan
- [x] bun run build
- [x] Browser checked normal mode vs Book focus mode visibility
- [x] Browser checked final story content and chapter boundary pagination


Made with [Cursor](https://cursor.com)