### PR TITLE
Make book mode fullscreen with gesture-based chrome

### DIFF
--- a/app/assets/css/reading.css
+++ b/app/assets/css/reading.css
@@ -183,6 +183,10 @@ html.dark .reading-prose hr {
   overflow: hidden;
 }
 
+.book-focus-shell > div {
+  height: 100%;
+}
+
 .book-focus-page {
   height: 100svh;
   min-height: 100svh;
@@ -191,33 +195,36 @@ html.dark .reading-prose hr {
 }
 
 .book-focus-content {
+  position: relative;
   box-sizing: border-box;
-  display: flex;
-  align-items: center;
-  justify-content: center;
+  display: block;
   width: 100%;
   height: 100svh;
-  padding: clamp(0.75rem, 2vw, 1.5rem);
+  padding: 0;
 }
 
 .book-focus-content > .story-reader {
-  display: flex;
-  align-items: center;
-  justify-content: center;
+  position: relative;
+  display: block;
   width: 100%;
   height: 100%;
 }
 
-.book-mode-reader {
-  --book-page-height: min(760px, calc(100svh - 8.5rem));
-
-  display: grid;
-  grid-template-rows: minmax(0, 1fr) auto;
-  align-items: center;
-  gap: clamp(0.75rem, 2vh, 1.25rem);
-  width: min(96vw, 1180px);
+.story-reader--book {
   height: 100%;
-  margin: 0 auto;
+  min-height: 100svh;
+}
+
+.book-mode-reader {
+  --book-page-height: 100svh;
+  --book-page-width: calc((100vw - 18px) / 2);
+
+  position: absolute;
+  inset: 0;
+  display: block;
+  width: 100%;
+  height: 100%;
+  margin: 0;
   outline: none;
 }
 
@@ -238,10 +245,13 @@ html.dark .reading-prose hr {
   color: var(--ink-text);
   box-shadow: 0 14px 32px rgba(35, 24, 15, 0.14);
   backdrop-filter: blur(10px);
+  opacity: 0;
+  pointer-events: none;
   transition:
     border-color 0.2s ease,
     color 0.2s ease,
-    transform 0.2s ease;
+    transform 0.2s ease,
+    opacity 0.2s ease;
 }
 
 .book-focus-exit:hover {
@@ -250,11 +260,33 @@ html.dark .reading-prose hr {
   transform: translateY(-1px);
 }
 
+.book-mode-reader:hover .book-focus-exit,
+.book-mode-reader:hover .book-controls,
+.book-mode-reader.is-controls-visible .book-focus-exit,
+.book-mode-reader.is-controls-visible .book-controls {
+  opacity: 1;
+  pointer-events: auto;
+}
+
+@media (hover: none) {
+  .book-mode-reader:hover .book-focus-exit,
+  .book-mode-reader:hover .book-controls {
+    opacity: 0;
+    pointer-events: none;
+  }
+
+  .book-mode-reader.is-controls-visible .book-focus-exit,
+  .book-mode-reader.is-controls-visible .book-controls {
+    opacity: 1;
+    pointer-events: auto;
+  }
+}
+
 .book-mode-source {
   position: fixed;
   top: 0;
   left: -200vw;
-  width: min(42vw, 470px);
+  width: var(--book-page-width);
   height: auto;
   visibility: hidden;
   pointer-events: none;
@@ -264,7 +296,7 @@ html.dark .reading-prose hr {
   position: fixed;
   top: 0;
   left: -200vw;
-  width: min(42vw, 470px);
+  width: var(--book-page-width);
   height: var(--book-page-height);
   visibility: hidden;
   pointer-events: none;
@@ -272,37 +304,42 @@ html.dark .reading-prose hr {
 }
 
 .book-stage {
-  position: relative;
+  position: absolute;
+  inset: 0;
   display: flex;
-  align-items: center;
-  justify-content: center;
+  align-items: stretch;
+  justify-content: stretch;
   width: 100%;
-  min-height: 0;
-  padding: clamp(0.75rem, 2vw, 1.5rem);
+  height: 100%;
+  min-height: 100%;
+  padding: 0;
   perspective: 1800px;
+  touch-action: none;
 }
 
 .book-cover {
   position: absolute;
-  inset: clamp(0.35rem, 1vw, 0.8rem);
-  border-radius: 18px 24px 24px 18px;
+  inset: 0;
+  z-index: 0;
+  border-radius: 0;
   background:
     linear-gradient(90deg, rgba(56, 28, 12, 0.42), transparent 8%, transparent 92%, rgba(36, 18, 8, 0.38)),
     linear-gradient(135deg, #5f2415, #2f1711 55%, #1f120f);
-  box-shadow: 0 34px 80px rgba(35, 24, 15, 0.32);
-  transform: rotateX(2deg);
+  box-shadow: none;
+  transform: none;
 }
 
 html.dark .book-cover {
-  box-shadow: 0 34px 80px rgba(0, 0, 0, 0.5);
+  box-shadow: none;
 }
 
 .book-spread {
   position: relative;
+  z-index: 1;
   display: grid;
   grid-template-columns: minmax(0, 1fr) 18px minmax(0, 1fr);
   width: 100%;
-  height: var(--book-page-height);
+  height: 100%;
   min-height: 0;
   transform-style: preserve-3d;
   isolation: isolate;
@@ -313,7 +350,7 @@ html.dark .book-cover {
   overflow: hidden;
   height: 100%;
   min-height: 0;
-  padding: clamp(1.5rem, 3vw, 3rem);
+  padding: clamp(1.75rem, 3.5vw, 3.5rem);
   background:
     radial-gradient(circle at 20% 10%, rgba(255, 255, 255, 0.65), transparent 36%),
     linear-gradient(90deg, rgba(124, 45, 18, 0.08), transparent 9%),
@@ -327,12 +364,12 @@ html.dark .book-cover {
 }
 
 .book-page-left {
-  border-radius: 10px 3px 3px 10px;
+  border-radius: 0;
   transform-origin: right center;
 }
 
 .book-page-right {
-  border-radius: 3px 10px 10px 3px;
+  border-radius: 0;
   transform-origin: left center;
   background:
     radial-gradient(circle at 80% 10%, rgba(255, 255, 255, 0.62), transparent 36%),
@@ -462,20 +499,39 @@ html.dark .book-cover {
 }
 
 .book-controls {
+  position: fixed;
+  left: 50%;
+  bottom: max(1rem, env(safe-area-inset-bottom, 0px));
+  z-index: 50;
   display: flex;
   align-items: center;
   justify-content: center;
-  gap: 1rem;
-  margin-top: 0;
+  gap: 0.75rem;
+  margin: 0;
+  padding: 0.5rem 0.75rem;
+  border: 1px solid var(--ink-border);
+  border-radius: 9999px;
+  background: color-mix(in srgb, var(--ink-paper) 92%, transparent);
   color: var(--ink-muted);
+  box-shadow: 0 14px 32px rgba(35, 24, 15, 0.14);
+  backdrop-filter: blur(10px);
+  transform: translateX(-50%);
+  opacity: 0;
+  pointer-events: none;
+  transition: opacity 0.2s ease;
 }
 
 .book-control {
-  min-height: 2.75rem;
-  padding: 0 1rem;
-  border: 1px solid var(--ink-border);
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 2.5rem;
+  height: 2.5rem;
+  min-height: 2.5rem;
+  padding: 0;
+  border: 1px solid transparent;
   border-radius: 9999px;
-  background: var(--ink-paper);
+  background: transparent;
   color: var(--ink-text);
   transition:
     border-color 0.2s ease,
@@ -499,33 +555,22 @@ html.dark .book-cover {
   min-width: 8.5rem;
   text-align: center;
   font-size: 0.875rem;
+  white-space: nowrap;
 }
 
 @media (max-width: 767px) {
-  .book-focus-content {
-    padding: 0.75rem;
-  }
-
-  .book-mode-reader,
-  .book-mode-source,
-  .book-page-measure {
-    --book-page-height: min(680px, calc(100svh - 8rem));
-
-    width: min(92vw, 430px);
-  }
-
-  .book-stage {
-    padding: 3.75rem 0 0;
+  .book-mode-reader {
+    --book-page-width: 100vw;
   }
 
   .book-focus-exit {
-    top: 0.75rem;
+    top: max(0.75rem, env(safe-area-inset-top, 0px));
     right: 0.75rem;
   }
 
   .book-spread {
     grid-template-columns: minmax(0, 1fr);
-    height: var(--book-page-height);
+    height: 100%;
     min-height: 0;
   }
 
@@ -534,7 +579,7 @@ html.dark .book-cover {
   .book-turn-face {
     height: var(--book-page-height);
     min-height: 0;
-    padding: 1.35rem;
+    padding: 1.5rem 1.25rem;
   }
 
   .book-mode-reader .book-page-measure {
@@ -546,7 +591,7 @@ html.dark .book-cover {
   }
 
   .book-page-left {
-    border-radius: 10px;
+    border-radius: 0;
   }
 
   .book-turn-sheet {
@@ -559,11 +604,12 @@ html.dark .book-cover {
   }
 
   .book-controls {
-    gap: 0.6rem;
+    gap: 0.5rem;
+    bottom: max(1.25rem, env(safe-area-inset-bottom, 0px));
   }
 
   .book-page-count {
-    min-width: 6rem;
+    min-width: 6.5rem;
   }
 }
 
@@ -577,7 +623,8 @@ html.dark .book-cover {
     transition: none;
   }
 
-  .book-focus-exit {
+  .book-focus-exit,
+  .book-controls {
     transition: none;
   }
 }

--- a/app/components/reading/BookModeReader.vue
+++ b/app/components/reading/BookModeReader.vue
@@ -2,9 +2,12 @@
   <section
     ref="readerRoot"
     class="book-mode-reader"
+    :class="{ 'is-controls-visible': isControlsVisible }"
     :data-reading-size="fontLevel"
     tabindex="0"
     aria-label="Book mode reader"
+    @mouseenter="onReaderMouseEnter"
+    @mouseleave="onReaderMouseLeave"
   >
     <div
       ref="sourceEl"
@@ -25,7 +28,7 @@
       class="book-focus-exit"
       data-testid="story-bookmode-toggle"
       aria-label="Switch to normal mode"
-      @click="setMode('scroll')"
+      @click="exitBookMode"
     >
       <svg
         xmlns="http://www.w3.org/2000/svg"
@@ -53,6 +56,10 @@
         'is-flipping-next': flipDirection === 'next',
         'is-flipping-prev': flipDirection === 'prev',
       }"
+      @pointerdown="onPointerDown"
+      @pointermove="onPointerMove"
+      @pointerup="onPointerUp"
+      @pointercancel="onPointerCancel"
     >
       <div class="book-cover" aria-hidden="true" />
       <div class="book-spread">
@@ -108,7 +115,20 @@
         aria-label="Previous page"
         @click="goPrev"
       >
-        Previous
+        <svg
+          xmlns="http://www.w3.org/2000/svg"
+          width="18"
+          height="18"
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          stroke-width="2"
+          stroke-linecap="round"
+          stroke-linejoin="round"
+          aria-hidden="true"
+        >
+          <path d="m15 18-6-6 6-6" />
+        </svg>
       </button>
       <span class="book-page-count" aria-live="polite">
         {{ pageLabel }}
@@ -121,7 +141,20 @@
         aria-label="Next page"
         @click="goNext"
       >
-        Next
+        <svg
+          xmlns="http://www.w3.org/2000/svg"
+          width="18"
+          height="18"
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          stroke-width="2"
+          stroke-linecap="round"
+          stroke-linejoin="round"
+          aria-hidden="true"
+        >
+          <path d="m9 18 6-6-6-6" />
+        </svg>
       </button>
     </div>
   </section>
@@ -132,6 +165,11 @@ const props = defineProps<{
   story: Record<string, unknown>;
   fontLevel: number;
 }>();
+
+const SWIPE_THRESHOLD = 50;
+const LONG_PRESS_MS = 450;
+const LONG_PRESS_SLOP = 10;
+const CONTROLS_HIDE_MS = 3000;
 
 const readerRoot = ref<HTMLElement | null>(null);
 const sourceEl = ref<HTMLElement | null>(null);
@@ -144,6 +182,7 @@ const prefersReducedMotion = ref(false);
 const turnFrontPage = ref("");
 const turnBackPage = ref("");
 const pendingPage = ref<number | null>(null);
+const isControlsVisible = ref(false);
 const { setMode } = useReadingMode();
 const { playFlip } = usePageFlipAudio();
 const { pages, pageCount, isPaginating, schedulePagination } = useBookPagination({
@@ -156,6 +195,14 @@ let mutationObserver: MutationObserver | undefined;
 let mediaQuery: MediaQueryList | undefined;
 let reducedMotionQuery: MediaQueryList | undefined;
 let flipTimer: ReturnType<typeof setTimeout> | undefined;
+let longPressTimer: ReturnType<typeof setTimeout> | undefined;
+let controlsHideTimer: ReturnType<typeof setTimeout> | undefined;
+let pointerId: number | null = null;
+let pointerStartX = 0;
+let pointerStartY = 0;
+let pointerMoved = false;
+let longPressTriggered = false;
+let isCoarsePointer = false;
 
 const step = computed(() => isSinglePage.value ? 1 : 2);
 const spreadStart = computed(() => isSinglePage.value ? currentPage.value : Math.floor(currentPage.value / 2) * 2);
@@ -236,14 +283,52 @@ async function turnPage(direction: "next" | "prev") {
 }
 
 function goNext() {
+  if (isCoarsePointer && isControlsVisible.value) scheduleControlsHide();
   void turnPage("next");
 }
 
 function goPrev() {
+  if (isCoarsePointer && isControlsVisible.value) scheduleControlsHide();
   void turnPage("prev");
 }
 
+function clearControlsHideTimer() {
+  clearTimeout(controlsHideTimer);
+  controlsHideTimer = undefined;
+}
+
+function scheduleControlsHide() {
+  clearControlsHideTimer();
+  if (!isCoarsePointer) return;
+  controlsHideTimer = setTimeout(() => {
+    isControlsVisible.value = false;
+  }, CONTROLS_HIDE_MS);
+}
+
+function showControls() {
+  isControlsVisible.value = true;
+  scheduleControlsHide();
+}
+
+function hideControls() {
+  clearControlsHideTimer();
+  isControlsVisible.value = false;
+}
+
+function exitBookMode() {
+  hideControls();
+  setMode("scroll");
+}
+
+function isTypingTarget(target: EventTarget | null) {
+  if (!(target instanceof HTMLElement)) return false;
+  const tag = target.tagName;
+  return tag === "INPUT" || tag === "TEXTAREA" || tag === "SELECT" || target.isContentEditable;
+}
+
 function onKeydown(event: KeyboardEvent) {
+  if (isTypingTarget(event.target)) return;
+
   if (event.key === "ArrowRight") {
     event.preventDefault();
     goNext();
@@ -255,9 +340,89 @@ function onKeydown(event: KeyboardEvent) {
   }
 }
 
+function onReaderMouseEnter() {
+  if (isCoarsePointer) return;
+  isControlsVisible.value = true;
+}
+
+function onReaderMouseLeave() {
+  if (isCoarsePointer) return;
+  isControlsVisible.value = false;
+}
+
+function clearLongPressTimer() {
+  clearTimeout(longPressTimer);
+  longPressTimer = undefined;
+}
+
+function onPointerDown(event: PointerEvent) {
+  if (event.pointerType === "mouse" && event.button !== 0) return;
+
+  pointerId = event.pointerId;
+  pointerStartX = event.clientX;
+  pointerStartY = event.clientY;
+  pointerMoved = false;
+  longPressTriggered = false;
+  clearLongPressTimer();
+
+  if (event.pointerType !== "mouse") {
+    longPressTimer = setTimeout(() => {
+      longPressTriggered = true;
+      showControls();
+    }, LONG_PRESS_MS);
+  }
+
+  (event.currentTarget as HTMLElement | null)?.setPointerCapture?.(event.pointerId);
+}
+
+function onPointerMove(event: PointerEvent) {
+  if (pointerId === null || event.pointerId !== pointerId) return;
+
+  const dx = event.clientX - pointerStartX;
+  const dy = event.clientY - pointerStartY;
+
+  if (Math.abs(dx) > LONG_PRESS_SLOP || Math.abs(dy) > LONG_PRESS_SLOP) {
+    pointerMoved = true;
+    clearLongPressTimer();
+  }
+}
+
+function onPointerUp(event: PointerEvent) {
+  if (pointerId === null || event.pointerId !== pointerId) return;
+
+  const dx = event.clientX - pointerStartX;
+  const dy = event.clientY - pointerStartY;
+  clearLongPressTimer();
+
+  if (longPressTriggered) {
+    pointerId = null;
+    return;
+  }
+
+  if (Math.abs(dx) >= SWIPE_THRESHOLD && Math.abs(dx) > Math.abs(dy)) {
+    if (isControlsVisible.value && isCoarsePointer) hideControls();
+    if (dx < 0) goNext();
+    else goPrev();
+  } else if (!pointerMoved && isCoarsePointer && isControlsVisible.value) {
+    const target = event.target;
+    if (target instanceof Element && !target.closest(".book-controls, .book-focus-exit")) {
+      hideControls();
+    }
+  }
+
+  pointerId = null;
+}
+
+function onPointerCancel(event: PointerEvent) {
+  if (pointerId === null || event.pointerId !== pointerId) return;
+  clearLongPressTimer();
+  pointerId = null;
+}
+
 function updateMediaState() {
   isSinglePage.value = mediaQuery?.matches ?? false;
   prefersReducedMotion.value = reducedMotionQuery?.matches ?? false;
+  isCoarsePointer = window.matchMedia("(hover: none), (pointer: coarse)").matches;
   clampCurrentPage();
   schedulePagination();
 }
@@ -278,7 +443,7 @@ onMounted(() => {
   reducedMotionQuery = window.matchMedia("(prefers-reduced-motion: reduce)");
   mediaQuery.addEventListener("change", updateMediaState);
   reducedMotionQuery.addEventListener("change", updateMediaState);
-  readerRoot.value?.addEventListener("keydown", onKeydown);
+  window.addEventListener("keydown", onKeydown);
   observeRenderedContent();
   updateMediaState();
 });
@@ -287,8 +452,10 @@ onBeforeUnmount(() => {
   mutationObserver?.disconnect();
   mediaQuery?.removeEventListener("change", updateMediaState);
   reducedMotionQuery?.removeEventListener("change", updateMediaState);
-  readerRoot.value?.removeEventListener("keydown", onKeydown);
+  window.removeEventListener("keydown", onKeydown);
   clearTimeout(flipTimer);
+  clearLongPressTimer();
+  clearControlsHideTimer();
 });
 
 watch([pageCount, isSinglePage], clampCurrentPage);

--- a/app/components/reading/StoryReader.vue
+++ b/app/components/reading/StoryReader.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="story-reader">
+  <div class="story-reader" :class="{ 'story-reader--book': mode === 'book' }">
     <ClientOnly v-if="mode === 'book'">
       <BookModeReader
         v-if="story"


### PR DESCRIPTION
## Summary
- Book mode fills the viewport with the page spread edge to edge
- Controls stay hidden until desktop hover or mobile long-press
- Navigate with arrow keys, swipe, or the revealed prev/next controls

## Test plan
- [ ] Open a story in book mode — spread fills the screen with no persistent chrome
- [ ] Desktop: hover reveals exit + pagination; ←/→ turn pages
- [ ] Mobile: swipe L/R navigates; long-press shows controls; minimize returns to scroll mode


Made with [Cursor](https://cursor.com)